### PR TITLE
Fix incorrect __pbump() usage (do not use it for size_t type)

### DIFF
--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -474,7 +474,13 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::str(const string_type& __s)
                    const_cast<char_type*>(__str_.data()) + __str_.size());
         if (__mode_ & (ios_base::app | ios_base::ate))
         {
-            this->__pbump(__sz);
+            while (__sz > INT_MAX)
+            {
+                this->pbump(INT_MAX);
+                __sz -= INT_MAX;
+            }
+            if (__sz > 0)
+                this->pbump(__sz);
         }
     }
 }


### PR DESCRIPTION
As pointed by Mordante in the review of [1].    

  [1]: https://reviews.llvm.org/D146294

Follow-up for: https://github.com/ClickHouse/llvm-project/pull/9 (cc @alexey-milovidov @rschu1ze )