### PR TITLE
Don't export compile commands by default

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -244,10 +244,6 @@ list(INSERT CMAKE_MODULE_PATH 0
   "${LLVM_COMMON_CMAKE_UTILS}/Modules"
   )
 
-# Generate a CompilationDatabase (compile_commands.json file) for our build,
-# for use by clang_complete, YouCompleteMe, etc.
-set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-
 option(LLVM_INSTALL_BINUTILS_SYMLINKS
   "Install symlinks from the binutils tool names to the corresponding LLVM tools." OFF)
 


### PR DESCRIPTION
We already define `CMAKE_EXPORT_COMPILE_COMMANDS` in our CMakeLists.txt and LLVM is the only contrib which doesn't have its own independent CMakeLists.txt. After this PR, we can precisely control which targets need to be exported, which lowers the memory consumption of clangd.
