### PR TITLE
Add string/string_view spaceship operators and add option to enable <regex>

### DIFF
--- a/libcxx/docs/Status/Cxx2bIssues.csv
+++ b/libcxx/docs/Status/Cxx2bIssues.csv
@@ -7,7 +7,7 @@
 "`3236 <https://wg21.link/LWG3236>`__","Random access iterator requirements lack limiting relational operators domain to comparing those from the same range","November 2020","|Nothing To Do|","","|ranges|"
 "`3265 <https://wg21.link/LWG3265>`__","``move_iterator``'s conversions are more broken after P1207","November 2020","Fixed by `LWG3435 <https://wg21.link/LWG3435>`__",""
 "`3435 <https://wg21.link/LWG3435>`__","``three_way_comparable_with<reverse_iterator<int*>, reverse_iterator<const int*>>``","November 2020","|Complete|","13.0"
-"`3432 <https://wg21.link/LWG3432>`__","Missing requirement for ``comparison_category``","November 2020","","","|spaceship|"
+"`3432 <https://wg21.link/LWG3432>`__","Missing requirement for ``comparison_category``","November 2020","|Complete|","16.0","|spaceship|"
 "`3447 <https://wg21.link/LWG3447>`__","Deduction guides for ``take_view`` and ``drop_view`` have different constraints","November 2020","|Complete|","14.0"
 "`3450 <https://wg21.link/LWG3450>`__","The const overloads of ``take_while_view::begin/end`` are underconstrained","November 2020","","","|ranges|"
 "`3464 <https://wg21.link/LWG3464>`__","``istream::gcount()`` can overflow","November 2020","",""

--- a/libcxx/include/__compare/ordering.h
+++ b/libcxx/include/__compare/ordering.h
@@ -312,6 +312,12 @@ inline constexpr strong_ordering strong_ordering::equal(_OrdResult::__equiv);
 inline constexpr strong_ordering strong_ordering::equivalent(_OrdResult::__equiv);
 inline constexpr strong_ordering strong_ordering::greater(_OrdResult::__greater);
 
+/// [cmp.categories.pre]/1
+/// The types partial_ordering, weak_ordering, and strong_ordering are
+/// collectively termed the comparison category types.
+template <class _Tp>
+concept __comparison_category = __one_of_v<_Tp, partial_ordering, weak_ordering, strong_ordering>;
+
 #endif // _LIBCPP_STD_VER > 17
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -17,6 +17,7 @@
 #include <__config>
 #include <__functional/hash.h>
 #include <__iterator/iterator_traits.h>
+#include <compare>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -193,6 +194,9 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<char>
     typedef streamoff off_type;
     typedef streampos pos_type;
     typedef mbstate_t state_type;
+#if _LIBCPP_STD_VER > 17
+    using comparison_category = strong_ordering;
+#endif
 
     static inline _LIBCPP_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
@@ -307,6 +311,9 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<wchar_t>
     typedef streamoff off_type;
     typedef streampos pos_type;
     typedef mbstate_t state_type;
+#  if _LIBCPP_STD_VER > 17
+    using comparison_category = strong_ordering;
+#  endif
 
     static inline _LIBCPP_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
@@ -423,6 +430,9 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<char8_t>
     typedef streamoff      off_type;
     typedef u8streampos    pos_type;
     typedef mbstate_t      state_type;
+#  if _LIBCPP_STD_VER > 17
+    using comparison_category = strong_ordering;
+#  endif
 
     static inline constexpr void assign(char_type& __c1, const char_type& __c2) noexcept
         {__c1 = __c2;}
@@ -524,6 +534,9 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<char16_t>
     typedef streamoff      off_type;
     typedef u16streampos   pos_type;
     typedef mbstate_t      state_type;
+#if _LIBCPP_STD_VER > 17
+    using comparison_category = strong_ordering;
+#endif
 
     static inline _LIBCPP_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
@@ -615,6 +628,9 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<char32_t>
     typedef streamoff      off_type;
     typedef u32streampos   pos_type;
     typedef mbstate_t      state_type;
+#if _LIBCPP_STD_VER > 17
+    using comparison_category = strong_ordering;
+#endif
 
     static inline _LIBCPP_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -7,8 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// See https://github.com/ClickHouse/ClickHouse/pull/58681
+#ifndef ENABLE_STD_REGEX
+// Disable std::regex by default, see https://github.com/ClickHouse/ClickHouse/pull/58681
 #error "<regex> is disabled. Use <Common/re2.h> instead"
+#endif
 
 #ifndef _LIBCPP_REGEX
 #define _LIBCPP_REGEX

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -13,6 +13,9 @@
 /*
     string synopsis
 
+#include <compare>
+#include <initializer_list>
+
 namespace std
 {
 
@@ -43,11 +46,13 @@ template <class stateT> bool operator!=(const fpos<stateT>& x, const fpos<stateT
 template <class charT>
 struct char_traits
 {
-    typedef charT     char_type;
-    typedef ...       int_type;
-    typedef streamoff off_type;
-    typedef streampos pos_type;
-    typedef mbstate_t state_type;
+    using char_type           = charT;
+    using int_type            = ...;
+    using off_type            = streamoff;
+    using pos_type            = streampos;
+    using state_type          = mbstate_t;
+    using comparison_category = strong_ordering; // Since C++20 only for the specializations
+                                                 // char, wchar_t, char8_t, char16_t, and char32_t.
 
     static void assign(char_type& c1, const char_type& c2) noexcept;
     static constexpr bool eq(char_type c1, char_type c2) noexcept;
@@ -370,60 +375,68 @@ bool operator==(const basic_string<charT, traits, Allocator>& lhs,
                 const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20
 
 template<class charT, class traits, class Allocator>
-bool operator==(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20
+bool operator==(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
 bool operator==(const basic_string<charT,traits,Allocator>& lhs, const charT* rhs) noexcept;    // constexpr since C++20
 
 template<class charT, class traits, class Allocator>
 bool operator!=(const basic_string<charT,traits,Allocator>& lhs,
-                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20
+                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator!=(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20
+bool operator!=(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator!=(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20
+bool operator!=(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
 bool operator< (const basic_string<charT, traits, Allocator>& lhs,
-                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20
+                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator< (const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20
+bool operator< (const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator< (const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20
+bool operator< (const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
 bool operator> (const basic_string<charT, traits, Allocator>& lhs,
-                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20
+                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator> (const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20
+bool operator> (const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator> (const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20
+bool operator> (const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
 bool operator<=(const basic_string<charT, traits, Allocator>& lhs,
-                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20
+                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator<=(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20
+bool operator<=(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator<=(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20
+bool operator<=(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
 bool operator>=(const basic_string<charT, traits, Allocator>& lhs,
-                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20
+                const basic_string<charT, traits, Allocator>& rhs) noexcept;                    // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator>=(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20
+bool operator>=(const basic_string<charT, traits, Allocator>& lhs, const charT* rhs) noexcept;  // constexpr since C++20, removed in C++20
 
 template<class charT, class traits, class Allocator>
-bool operator>=(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20
+bool operator>=(const charT* lhs, const basic_string<charT, traits, Allocator>& rhs) noexcept;  // constexpr since C++20, removed in C++20
+
+template<class charT, class traits, class Allocator>                                            // since C++20
+constexpr see below operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+                                const basic_string<charT, traits, Allocator>& rhs) noexcept;
+
+template<class charT, class traits, class Allocator>                                            // since C++20
+constexpr see below operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+                                const charT* rhs) noexcept;
 
 template<class charT, class traits, class Allocator>
 void swap(basic_string<charT, traits, Allocator>& lhs,
@@ -4149,10 +4162,14 @@ bool
 operator==(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
            const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
 {
+#if _LIBCPP_STD_VER > 17
+    return basic_string_view<_CharT, _Traits>(__lhs) == basic_string_view<_CharT, _Traits>(__rhs);
+#else
     size_t __lhs_sz = __lhs.size();
     return __lhs_sz == __rhs.size() && _Traits::compare(__lhs.data(),
                                                         __rhs.data(),
                                                         __lhs_sz) == 0;
+#endif
 }
 
 template<class _Allocator>
@@ -4174,6 +4191,7 @@ operator==(const basic_string<char, char_traits<char>, _Allocator>& __lhs,
     return true;
 }
 
+#if _LIBCPP_STD_VER <= 17
 template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI
 bool
@@ -4186,6 +4204,7 @@ operator==(const _CharT* __lhs,
     if (__lhs_len != __rhs.size()) return false;
     return __rhs.compare(0, _String::npos, __lhs, __lhs_len) == 0;
 }
+#endif // _LIBCPP_STD_VER <= 17
 
 template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI
@@ -4193,12 +4212,33 @@ bool
 operator==(const basic_string<_CharT,_Traits,_Allocator>& __lhs,
            const _CharT* __rhs) _NOEXCEPT
 {
+#if _LIBCPP_STD_VER > 17
+    return basic_string_view<_CharT, _Traits>(__lhs) == basic_string_view<_CharT, _Traits>(__rhs);
+#else
     typedef basic_string<_CharT, _Traits, _Allocator> _String;
     _LIBCPP_ASSERT(__rhs != nullptr, "operator==(basic_string, char*): received nullptr");
     size_t __rhs_len = _Traits::length(__rhs);
     if (__rhs_len != __lhs.size()) return false;
     return __lhs.compare(0, _String::npos, __rhs, __rhs_len) == 0;
+#endif
 }
+
+#if _LIBCPP_STD_VER > 17
+
+template <class _CharT, class _Traits, class _Allocator>
+_LIBCPP_HIDE_FROM_ABI constexpr auto operator<=>(
+    const basic_string<_CharT, _Traits, _Allocator>& __lhs,
+    const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept {
+    return basic_string_view<_CharT, _Traits>(__lhs) <=> basic_string_view<_CharT, _Traits>(__rhs);
+}
+
+template <class _CharT, class _Traits, class _Allocator>
+_LIBCPP_HIDE_FROM_ABI constexpr auto
+operator<=>(const basic_string<_CharT, _Traits, _Allocator>& __lhs, const _CharT* __rhs) {
+    return basic_string_view<_CharT, _Traits>(__lhs) <=> basic_string_view<_CharT, _Traits>(__rhs);
+}
+
+#else // _LIBCPP_STD_VER > 17
 
 template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_AFTER_CXX17 _LIBCPP_HIDE_FROM_ABI
@@ -4342,6 +4382,7 @@ operator>=(const _CharT* __lhs,
 {
     return !(__lhs < __rhs);
 }
+#endif // _LIBCPP_STD_VER > 17
 
 // operator +
 

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -14,6 +14,8 @@
 
     string_view synopsis
 
+#include <compare>
+
 namespace std {
 
     // 7.2, Class template basic_string_view
@@ -30,21 +32,25 @@ namespace std {
     template<class charT, class traits>
     constexpr bool operator==(basic_string_view<charT, traits> x,
                               basic_string_view<charT, traits> y) noexcept;
-    template<class charT, class traits>
+    template<class charT, class traits>                                                            // Removed in C++20
     constexpr bool operator!=(basic_string_view<charT, traits> x,
                               basic_string_view<charT, traits> y) noexcept;
-    template<class charT, class traits>
+    template<class charT, class traits>                                                            // Removed in C++20
     constexpr bool operator< (basic_string_view<charT, traits> x,
                                  basic_string_view<charT, traits> y) noexcept;
-    template<class charT, class traits>
+    template<class charT, class traits>                                                            // Removed in C++20
     constexpr bool operator> (basic_string_view<charT, traits> x,
                               basic_string_view<charT, traits> y) noexcept;
-    template<class charT, class traits>
+    template<class charT, class traits>                                                            // Removed in C++20
     constexpr bool operator<=(basic_string_view<charT, traits> x,
                                  basic_string_view<charT, traits> y) noexcept;
-    template<class charT, class traits>
+    template<class charT, class traits>                                                            // Removed in C++20
     constexpr bool operator>=(basic_string_view<charT, traits> x,
                               basic_string_view<charT, traits> y) noexcept;
+    template<class charT, class traits>                                                            // Since C++20
+    constexpr see below operator<=>(basic_string_view<charT, traits> x,
+                                    basic_string_view<charT, traits> y) noexcept;
+
     // see below, sufficient additional overloads of comparison functions
 
     // 7.10, Inserters and extractors
@@ -770,6 +776,8 @@ bool operator==(basic_string_view<_CharT, _Traits> __lhs,
     return __lhs.compare(__rhs) == 0;
 }
 
+#if _LIBCPP_STD_VER < 20
+// This overload is automatically generated in C++20.
 template<class _CharT, class _Traits, int = 2>
 _LIBCPP_CONSTEXPR_AFTER_CXX11 _LIBCPP_INLINE_VISIBILITY
 bool operator==(typename common_type<basic_string_view<_CharT, _Traits> >::type __lhs,
@@ -778,7 +786,41 @@ bool operator==(typename common_type<basic_string_view<_CharT, _Traits> >::type 
     if ( __lhs.size() != __rhs.size()) return false;
     return __lhs.compare(__rhs) == 0;
 }
+#endif // _LIBCPP_STD_VER > 17
 
+// operator <=>
+
+#if _LIBCPP_STD_VER > 17
+
+template <class _CharT, class _Traits>
+_LIBCPP_HIDE_FROM_ABI constexpr auto
+operator<=>(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) noexcept {
+    if constexpr (requires { typename _Traits::comparison_category; }) {
+        // [string.view]/4
+        static_assert(
+            __comparison_category<typename _Traits::comparison_category>,
+            "return type is not a comparison category type");
+        return static_cast<typename _Traits::comparison_category>(__lhs.compare(__rhs) <=> 0);
+    } else {
+        return static_cast<weak_ordering>(__lhs.compare(__rhs) <=> 0);
+    }
+}
+
+template <class _CharT, class _Traits, int = 1>
+_LIBCPP_HIDE_FROM_ABI constexpr auto operator<=>(
+    basic_string_view<_CharT, _Traits> __lhs, common_type_t<basic_string_view<_CharT, _Traits>> __rhs) noexcept {
+    if constexpr (requires { typename _Traits::comparison_category; }) {
+        // [string.view]/4
+        static_assert(
+            __comparison_category<typename _Traits::comparison_category>,
+            "return type is not a comparison category type");
+        return static_cast<typename _Traits::comparison_category>(__lhs.compare(__rhs) <=> 0);
+    } else {
+        return static_cast<weak_ordering>(__lhs.compare(__rhs) <=> 0);
+    }
+}
+
+#else //  _LIBCPP_STD_VER > 17
 
 // operator !=
 template<class _CharT, class _Traits>
@@ -911,6 +953,7 @@ bool operator>=(typename common_type<basic_string_view<_CharT, _Traits> >::type 
     return __lhs.compare(__rhs) >= 0;
 }
 
+#endif //  _LIBCPP_STD_VER > 17
 
 template<class _CharT, class _Traits>
 basic_ostream<_CharT, _Traits>&

--- a/libcxx/test/std/strings/basic.string/string.nonmembers/string.cmp/comparison.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.nonmembers/string.cmp/comparison.pass.cpp
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Starting with C++20 the spaceship operator was included. This tests
+// comparison in that context, thus doesn't support older language versions.
+// These are tested per operator.
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <string>
+
+// template<class charT, class traits, class Allocator>
+//   see below operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+//                         const basic_string<charT, traits, Allocator>& rhs) noexcept;
+// template<class charT, class traits, class Allocator>
+//   see below operator<=>(const basic_string<charT, traits, Allocator>& lhs,
+//                         const charT* rhs);
+
+#include <string>
+
+#include <array>
+#include <cassert>
+#include <string_view>
+
+#include "constexpr_char_traits.h"
+#include "make_string.h"
+#include "test_comparisons.h"
+#include "test_macros.h"
+
+#define STR(S) MAKE_STRING(CharT, S)
+
+template <class T, class Ordering = std::strong_ordering>
+constexpr void test() {
+  AssertOrderAreNoexcept<T>();
+  AssertOrderReturn<Ordering, T>();
+
+  using CharT = typename T::value_type;
+  AssertOrderReturn<Ordering, T, const CharT*>();
+
+  // sorted values
+  std::array v{
+      STR(""),
+      STR("abc"),
+      STR("abcdef"),
+      STR("acb"),
+  };
+
+  // sorted values with embedded NUL character
+  std::array vn{
+      STR("abc"),
+      STR("abc\0"),
+      STR("abc\0def"),
+      STR("acb\0"),
+  };
+  static_assert(v.size() == vn.size());
+
+  for (size_t i = 0; i < v.size(); ++i) {
+    for (size_t j = 0; j < v.size(); ++j) {
+      assert(testOrder(v[i], v[j], i == j ? Ordering::equivalent : i < j ? Ordering::less : Ordering::greater));
+
+      assert(testOrder(
+          v[i],
+          std::basic_string<CharT>{v[j]}.c_str(),
+          i == j  ? Ordering::equivalent
+          : i < j ? Ordering::less
+                  : Ordering::greater));
+
+      // NUL test omitted for c-strings since it will fail.
+      assert(testOrder(vn[i], vn[j], i == j ? Ordering::equivalent : i < j ? Ordering::less : Ordering::greater));
+    }
+  }
+}
+
+constexpr bool test_all_types() {
+  test<std::string>();
+  test<std::basic_string<char, constexpr_char_traits<char>>, std::weak_ordering>();
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
+  test<std::wstring>();
+  test<std::basic_string<wchar_t, constexpr_char_traits<wchar_t>>, std::weak_ordering>();
+#endif
+  test<std::u8string>();
+  test<std::basic_string<char8_t, constexpr_char_traits<char8_t>>, std::weak_ordering>();
+  test<std::u16string>();
+  test<std::basic_string<char16_t, constexpr_char_traits<char16_t>>, std::weak_ordering>();
+  test<std::u32string>();
+  test<std::basic_string<char32_t, constexpr_char_traits<char32_t>>, std::weak_ordering>();
+
+  return true;
+}
+
+int main(int, char**) {
+  test_all_types();
+  static_assert(test_all_types());
+
+  return 0;
+}

--- a/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/types.pass.cpp
+++ b/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/types.pass.cpp
@@ -15,6 +15,7 @@
 // typedef streamoff off_type;
 // typedef streampos pos_type;
 // typedef mbstate_t state_type;
+// using comparison_category = strong_ordering;
 
 #include <string>
 #include <type_traits>
@@ -28,6 +29,9 @@ int main(int, char**)
     static_assert((std::is_same<std::char_traits<char>::off_type, std::streamoff>::value), "");
     static_assert((std::is_same<std::char_traits<char>::pos_type, std::streampos>::value), "");
     static_assert((std::is_same<std::char_traits<char>::state_type, std::mbstate_t>::value), "");
+#if TEST_STD_VER > 17
+    static_assert(std::is_same_v<std::char_traits<char>::comparison_category, std::strong_ordering>);
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/types.pass.cpp
+++ b/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/types.pass.cpp
@@ -15,6 +15,7 @@
 // typedef streamoff      off_type;
 // typedef u16streampos   pos_type;
 // typedef mbstate_t      state_type;
+// using comparison_category = strong_ordering;
 
 #include <string>
 #include <type_traits>
@@ -29,6 +30,9 @@ int main(int, char**)
     static_assert((std::is_same<std::char_traits<char16_t>::off_type, std::streamoff>::value), "");
     static_assert((std::is_same<std::char_traits<char16_t>::pos_type, std::u16streampos>::value), "");
     static_assert((std::is_same<std::char_traits<char16_t>::state_type, std::mbstate_t>::value), "");
+#if TEST_STD_VER > 17
+    static_assert(std::is_same_v<std::char_traits<char16_t>::comparison_category, std::strong_ordering>);
+#endif
 
     return 0;
 }

--- a/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/types.compile.pass.cpp
+++ b/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/types.compile.pass.cpp
@@ -15,13 +15,19 @@
 // typedef streamoff      off_type;
 // typedef u32streampos   pos_type;
 // typedef mbstate_t      state_type;
+// using comparison_category = strong_ordering;
 
 #include <string>
 #include <type_traits>
 #include <cstdint>
+
+#include "test_macros.h"
 
 static_assert((std::is_same<std::char_traits<char32_t>::char_type, char32_t>::value), "");
 static_assert((std::is_same<std::char_traits<char32_t>::int_type, std::uint_least32_t>::value), "");
 static_assert((std::is_same<std::char_traits<char32_t>::off_type, std::streamoff>::value), "");
 static_assert((std::is_same<std::char_traits<char32_t>::pos_type, std::u32streampos>::value), "");
 static_assert((std::is_same<std::char_traits<char32_t>::state_type, std::mbstate_t>::value), "");
+#if TEST_STD_VER > 17
+static_assert(std::is_same_v<std::char_traits<char32_t>::comparison_category, std::strong_ordering>);
+#endif

--- a/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/types.pass.cpp
+++ b/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/types.pass.cpp
@@ -16,6 +16,7 @@
 // typedef streamoff      off_type;
 // typedef u8streampos    pos_type;
 // typedef mbstate_t      state_type;
+// using comparison_category = strong_ordering;
 
 #include <string>
 #include <type_traits>
@@ -31,6 +32,7 @@ int main(int, char**)
     static_assert((std::is_same<std::char_traits<char8_t>::off_type,   std::streamoff>::value), "");
     static_assert((std::is_same<std::char_traits<char8_t>::pos_type,   std::u8streampos>::value), "");
     static_assert((std::is_same<std::char_traits<char8_t>::state_type, std::mbstate_t>::value), "");
+    static_assert(std::is_same_v<std::char_traits<char8_t>::comparison_category, std::strong_ordering>);
 #endif
 
   return 0;

--- a/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/types.pass.cpp
+++ b/libcxx/test/std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/types.pass.cpp
@@ -15,6 +15,7 @@
 // typedef streamoff off_type;
 // typedef streampos pos_type;
 // typedef mbstate_t state_type;
+// using comparison_category = strong_ordering;
 
 // UNSUPPORTED: no-wide-characters
 
@@ -30,6 +31,9 @@ int main(int, char**)
     static_assert((std::is_same<std::char_traits<wchar_t>::off_type, std::streamoff>::value), "");
     static_assert((std::is_same<std::char_traits<wchar_t>::pos_type, std::wstreampos>::value), "");
     static_assert((std::is_same<std::char_traits<wchar_t>::state_type, std::mbstate_t>::value), "");
+#if TEST_STD_VER > 17
+    static_assert(std::is_same_v<std::char_traits<wchar_t>::comparison_category, std::strong_ordering>);
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/strings/string.view/string.view.comparison/comparison.pass.cpp
+++ b/libcxx/test/std/strings/string.view/string.view.comparison/comparison.pass.cpp
@@ -1,0 +1,149 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Starting with C++20 the spaceship operator was included. This tests
+// comparison in that context, thus doesn't support older language versions.
+// These are tested per operator.
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <string_view>
+
+// template<class charT, class traits>
+//   constexpr bool operator==(basic_string_view<charT, traits> lhs, basic_string_view<charT, traits> rhs);
+// template<class charT, class traits>
+//   constexpr auto operator<=>(basic_string_view<charT, traits> lhs, basic_string_view<charT, traits> rhs);
+// (plus "sufficient additional overloads" to make implicit conversions work as intended)
+
+#include <string_view>
+
+#include <array>
+#include <cassert>
+#include <string>
+
+#include "constexpr_char_traits.h"
+#include "make_string.h"
+#include "test_comparisons.h"
+#include "test_macros.h"
+
+#define SV(S) MAKE_STRING_VIEW(CharT, S)
+
+// Copied from constexpr_char_traits, but it doesn't have a full implementation.
+// It has a comparison_category used in the tests.
+template <class CharT, class Ordering>
+struct char_traits {
+  using char_type           = CharT;
+  using int_type            = int;
+  using off_type            = std::streamoff;
+  using pos_type            = std::streampos;
+  using state_type          = std::mbstate_t;
+  using comparison_category = Ordering;
+
+  static constexpr void assign(char_type& __c1, const char_type& __c2) noexcept { __c1 = __c2; }
+  static constexpr bool eq(char_type __c1, char_type __c2) noexcept { return __c1 == __c2; }
+  static constexpr bool lt(char_type __c1, char_type __c2) noexcept { return __c1 < __c2; }
+  static constexpr int compare(const char_type* __s1, const char_type* __s2, size_t __n) {
+    for (; __n; --__n, ++__s1, ++__s2) {
+      if (lt(*__s1, *__s2))
+        return -1;
+      if (lt(*__s2, *__s1))
+        return 1;
+    }
+    return 0;
+  }
+
+  static constexpr size_t length(const char_type* __s);
+  static constexpr const char_type* find(const char_type* __s, size_t __n, const char_type& __a);
+  static constexpr char_type* move(char_type* __s1, const char_type* __s2, size_t __n);
+  static constexpr char_type* copy(char_type* __s1, const char_type* __s2, size_t __n);
+  static constexpr char_type* assign(char_type* __s, size_t __n, char_type __a);
+  static constexpr int_type not_eof(int_type __c) noexcept { return eq_int_type(__c, eof()) ? ~eof() : __c; }
+  static constexpr char_type to_char_type(int_type __c) noexcept { return char_type(__c); }
+  static constexpr int_type to_int_type(char_type __c) noexcept { return int_type(__c); }
+  static constexpr bool eq_int_type(int_type __c1, int_type __c2) noexcept { return __c1 == __c2; }
+  static constexpr int_type eof() noexcept { return int_type(EOF); }
+};
+
+template <class T, class Ordering = std::strong_ordering>
+constexpr void test() {
+  AssertOrderAreNoexcept<T>();
+  AssertOrderReturn<Ordering, T>();
+
+  using CharT = typename T::value_type;
+
+  // sorted values
+  std::array v{
+      SV(""),
+      SV("abc"),
+      SV("abcdef"),
+  };
+
+  // sorted values with embedded NUL character
+  std::array vn{
+      SV("abc"),
+      SV("abc\0"),
+      SV("abc\0def"),
+  };
+  static_assert(v.size() == vn.size());
+
+  for (size_t i = 0; i < v.size(); ++i) {
+    for (size_t j = 0; j < v.size(); ++j) {
+      assert(testOrder(v[i], v[j], i == j ? Ordering::equivalent : i < j ? Ordering::less : Ordering::greater));
+      assert(testOrder(
+          v[i],
+          std::basic_string<CharT>{v[j]},
+          i == j  ? Ordering::equivalent
+          : i < j ? Ordering::less
+                  : Ordering::greater));
+
+      assert(testOrder(
+          v[i],
+          std::basic_string<CharT>{v[j]}.c_str(),
+          i == j  ? Ordering::equivalent
+          : i < j ? Ordering::less
+                  : Ordering::greater));
+
+      // NUL test omitted for c-strings since it will fail.
+      assert(testOrder(vn[i], vn[j], i == j ? Ordering::equivalent : i < j ? Ordering::less : Ordering::greater));
+      assert(testOrder(
+          vn[i],
+          std::basic_string<CharT>{vn[j]},
+          i == j  ? Ordering::equivalent
+          : i < j ? Ordering::less
+                  : Ordering::greater));
+    }
+  }
+}
+
+template <class CharT>
+constexpr void test_all_orderings() {
+  test<std::basic_string_view<CharT>>(); // Strong ordering in its char_traits
+  test<std::basic_string_view<CharT, constexpr_char_traits<CharT>>,
+       std::weak_ordering>(); // No ordering in its char_traits
+  test<std::basic_string_view<CharT, char_traits<CharT, std::weak_ordering>>, std::weak_ordering>();
+  test<std::basic_string_view<CharT, char_traits<CharT, std::partial_ordering>>, std::partial_ordering>();
+}
+
+constexpr bool test_all_types() {
+  test_all_orderings<char>();
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
+  test_all_orderings<wchar_t>();
+#endif
+  test_all_orderings<char8_t>();
+  test_all_orderings<char16_t>();
+  test_all_orderings<char32_t>();
+
+  return true;
+}
+
+int main(int, char**) {
+  test_all_types();
+  static_assert(test_all_types());
+
+  return 0;
+}

--- a/libcxx/test/std/strings/string.view/string.view.comparison/comparison.verify.cpp
+++ b/libcxx/test/std/strings/string.view/string.view.comparison/comparison.verify.cpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <string_view>
+
+// template<class charT, class traits>
+//   constexpr auto operator<=>(basic_string_view<charT, traits> lhs, basic_string_view<charT, traits> rhs);
+//
+// LWG 3432
+// [string.view]/4
+// Mandates: R denotes a comparison category type ([cmp.categories]).
+
+#include <string_view>
+
+#include "test_macros.h"
+
+template <class CharT, class Ordering>
+struct traits {
+  typedef CharT char_type;
+  typedef int int_type;
+  typedef std::streamoff off_type;
+  typedef std::streampos pos_type;
+  typedef std::mbstate_t state_type;
+  using comparison_category = Ordering;
+
+  static constexpr void assign(char_type&, const char_type&) noexcept;
+  static constexpr bool eq(char_type&, const char_type&) noexcept;
+  static constexpr bool lt(char_type&, const char_type&) noexcept;
+
+  static constexpr int compare(const char_type*, const char_type*, size_t) { return 0; }
+  static constexpr size_t length(const char_type*);
+  static constexpr const char_type* find(const char_type*, size_t, const char_type&);
+  static constexpr char_type* move(char_type*, const char_type*, size_t);
+  static constexpr char_type* copy(char_type*, const char_type*, size_t);
+  static constexpr char_type* assign(char_type*, size_t, char_type);
+
+  static constexpr int_type not_eof(int_type) noexcept;
+
+  static constexpr char_type to_char_type(int_type) noexcept;
+
+  static constexpr int_type to_int_type(char_type) noexcept;
+
+  static constexpr bool eq_int_type(int_type, int_type) noexcept;
+
+  static constexpr int_type eof() noexcept;
+};
+
+template <class CharT, class Ordering, bool Valid>
+void test() {
+  using type = std::basic_string_view<CharT, traits<CharT, Ordering>>;
+  if constexpr (Valid)
+    type{} <=> type{};
+  else
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
+  // These diagnostics are issued for
+  // - Every invalid ordering
+  // - Every type
+  // expected-error-re@string_view:* 15 {{{{(static_assert|static assertion)}} failed{{.*}}return type is not a comparison category type}}
+
+  // This diagnostic is not issued for Ordering == void.
+  // expected-error@string_view:* 10 {{no matching conversion for static_cast from}}
+#else
+  // One less test run when wchar_t is unavailable.
+  // expected-error-re@string_view:* 12 {{{{(static_assert|static assertion)}} failed{{.*}}return type is not a comparison category type}}
+  // expected-error@string_view:* 8 {{no matching conversion for static_cast from}}
+#endif
+    type{} <=> type{};
+}
+
+template <class CharT>
+void test_all_orders() {
+  test<CharT, std::strong_ordering, true>();
+  test<CharT, std::weak_ordering, true>();
+  test<CharT, std::partial_ordering, true>();
+
+  test<CharT, void, false>();
+  test<CharT, int, false>();
+  test<CharT, float, false>();
+}
+
+void test_all_types() {
+  test_all_orders<char>();
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
+  test_all_orders<wchar_t>();
+#endif
+  test_all_orders<char8_t>();
+  test_all_orders<char16_t>();
+  test_all_orders<char32_t>();
+}

--- a/libcxx/test/support/constexpr_char_traits.h
+++ b/libcxx/test/support/constexpr_char_traits.h
@@ -23,6 +23,8 @@ struct constexpr_char_traits
     typedef std::streamoff off_type;
     typedef std::streampos pos_type;
     typedef std::mbstate_t state_type;
+    // The comparison_category is omitted so the class will have weak_ordering
+    // in C++20. This is intentional.
 
     static TEST_CONSTEXPR_CXX14 void assign(char_type& __c1, const char_type& __c2) TEST_NOEXCEPT
         {__c1 = __c2;}


### PR DESCRIPTION
This is a prepare for adding Ceph to ClickHouse (https://github.com/ClickHouse/ClickHouse/issues/62821):
- add spaceship operator to `std::string` and `std::string_view` (original commits https://github.com/llvm/llvm-project/commit/3818b4df1e102a0886138414c2d05fa66f2260cb and https://github.com/llvm/llvm-project/commit/22b5adff7189f3ca547f38d5e87a7fa9dda9c509)
- add an option to enable `std::regex`: unfortunately `std::regex` is used everywhere in Ceph and not easy to remove it (cc @rschu1ze)

@Algunenano please help to review [THANKS]