### PR TITLE
Fix macos stacktraces for 19.x

### DIFF
--- a/libcxx/include/__exception/exception.h
+++ b/libcxx/include/__exception/exception.h
@@ -22,7 +22,11 @@
 #endif
 
 #ifdef STD_EXCEPTION_HAS_STACK_TRACE
+#if defined(OS_DARWIN)
+extern "C" int backtrace(void **, int);
+#else
 extern "C" int unw_backtrace(void **, int);
+#endif
 #endif
 
 namespace std { // purposefully not using versioning namespace
@@ -103,7 +107,11 @@ private:
     int size = 0;
     void capture() _NOEXCEPT
     {
+#if defined(OS_DARWIN)
+        size = backtrace(frames, capacity);
+#else
         size = unw_backtrace(frames, capacity);
+#endif
     }
 #endif
 };


### PR DESCRIPTION
Use backtrace function instead of unw_backtrace for OS_DARWIN

Bringing back capturing exception stacktraces on MacOS (missing, presumably, after switching to [ClickHouse/llvmorg-16.0.6](https://github.com/ClickHouse/llvm-project/tree/ClickHouse/llvmorg-16.0.6) branch)

Ref: 2a8967b60cbe5bc2df253712bac343cc5263c5fc
