### PR TITLE
Fix C++23 build error in llvm/Support/Caching.h (#163545)

### DIFF
--- a/llvm/include/llvm/Support/Caching.h
+++ b/llvm/include/llvm/Support/Caching.h
@@ -17,10 +17,9 @@
 
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 namespace llvm {
-
-class MemoryBuffer;
 
 /// This class wraps an output stream for a file. Most clients should just be
 /// able to return an instance of this base class from the stream callback, but


### PR DESCRIPTION
Cherry-pick a simple fix from upstream. Fixes this:
```
FAILED: [code=1] contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o 
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/al13n/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DEXPERIMENTAL_KEY_INSTRUCTIONS -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D_LARGEFILE64_SOURCE -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -D_LIBUNWIND_IS_NATIVE_ONLY -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/al13n/ClickHouse/build/contrib/llvm-project/llvm/lib/Support -I/home/al13n/ClickHouse/contrib/llvm-project/llvm/lib/Support -I/home/al13n/ClickHouse/build/contrib/llvm-project/llvm/include -I/home/al13n/ClickHouse/contrib/llvm-project/llvm/include -I/home/al13n/ClickHouse/build/contrib/llvm-project/libcxx/include/c++/v1 -I/home/al13n/ClickHouse/contrib/llvm-project/libc -I/home/al13n/ClickHouse/base/glibc-compatibility/memcpy -isystem /home/al13n/ClickHouse/contrib/llvm-project/llvm/../third-party/siphash/include -isystem /home/al13n/ClickHouse/contrib/llvm-project/libcxx/include -isystem /home/al13n/ClickHouse/contrib/llvm-project/libcxxabi/include -isystem /home/al13n/ClickHouse/contrib/llvm-project/libunwind/include --gcc-toolchain=/home/al13n/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64 -fdiagnostics-color=always -Xclang -fuse-ctor-homing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -falign-functions=64 -mbranches-within-32B-boundaries -ffp-contract=off  -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fPIC -w -ffunction-sections -fdata-sections -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color  -g -Og -g  -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -std=c++23   -D OS_LINUX -Werror -Wno-deprecated-declarations -Wno-poison-system-directories -nostdinc++ -MD -MT contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o -MF contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o.d -o contrib/llvm-project/llvm/lib/Support/CMakeFiles/LLVMSupport.dir/Caching.cpp.o -c /home/al13n/ClickHouse/contrib/llvm-project/llvm/lib/Support/Caching.cpp
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/lib/Support/Caching.cpp:15:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Caching.h:19:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Error.h:17:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/ADT/Twine.h:12:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/ADT/SmallVector.h:19:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/algorithm:1865:
In file included from /home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__algorithm/inplace_merge.h:27:
/home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:75:19: error: invalid application of 'sizeof' to an incomplete type 'llvm::MemoryBuffer'
   75 |     static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
      |                   ^~~~~~~~~~~
/home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:290:7: note: in instantiation of member function 'std::default_delete<llvm::MemoryBuffer>::operator()' requested here
  290 |       __deleter_(__tmp);
      |       ^
/home/al13n/ClickHouse/contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259:71: note: in instantiation of member function 'std::unique_ptr<llvm::MemoryBuffer>::reset' requested here
  259 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 ~unique_ptr() { reset(); }
      |                                                                       ^
/home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Caching.h:121:62: note: in instantiation of member function 'std::unique_ptr<llvm::MemoryBuffer>::~unique_ptr' requested here
  121 |                                std::unique_ptr<MemoryBuffer> MB) {});
      |                                                              ^
/home/al13n/ClickHouse/contrib/llvm-project/llvm/include/llvm/Support/Caching.h:23:7: note: forward declaration of 'llvm::MemoryBuffer'
   23 | class MemoryBuffer;
      |       ^
1 error generated.
```