### PR TITLE
Add illumos support to libc++ and LLVM.

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -842,6 +842,7 @@ typedef __char32_t char32_t;
         defined(__APPLE__) ||                                                                                          \
         defined(__MVS__) ||                                                                                            \
         defined(_AIX) ||                                                                                               \
+        defined(__sun) ||                                                                                              \
         defined(__EMSCRIPTEN__)
 // clang-format on
 #      undef _LIBCPP_HAS_THREAD_API_PTHREAD
@@ -925,7 +926,7 @@ typedef __char32_t char32_t;
 #  endif
 
 #  if defined(__BIONIC__) || defined(__NuttX__) || defined(__Fuchsia__) || defined(__wasi__) ||                        \
-      _LIBCPP_HAS_MUSL_LIBC || defined(__OpenBSD__) || defined(__LLVM_LIBC__)
+      _LIBCPP_HAS_MUSL_LIBC || defined(__OpenBSD__) || defined(__LLVM_LIBC__) || defined(__sun)
 #    define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
 #  endif
 

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -389,6 +389,21 @@ public:
   static const mask xdigit       = _ISXDIGIT;
   static const mask blank        = _ISBLANK;
   static const mask __regex_word = 0x8000;
+#  elif defined(__sun)
+  // illumos/Solaris ctype masks. Note: _ISPRINT is 0x8000, so we use
+  // 0x10000 for __regex_word to avoid overlap.
+  typedef unsigned int mask;
+  static const mask space        = _ISSPACE;
+  static const mask print        = _ISPRINT;
+  static const mask cntrl        = _ISCNTRL;
+  static const mask upper        = _ISUPPER;
+  static const mask lower        = _ISLOWER;
+  static const mask alpha        = _ISALPHA;
+  static const mask digit        = _ISDIGIT;
+  static const mask punct        = _ISPUNCT;
+  static const mask xdigit       = _ISXDIGIT;
+  static const mask blank        = _ISBLANK;
+  static const mask __regex_word = 0x10000;
 #  elif defined(_NEWLIB_VERSION)
   // Same type as Newlib's _ctype_ array in newlib/libc/include/ctype.h.
   typedef char mask;

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -133,7 +133,7 @@
 #      include <__locale_dir/locale_base_api/android.h>
 #    elif defined(__OpenBSD__)
 #      include <__locale_dir/locale_base_api/openbsd.h>
-#    elif defined(__wasi__) || _LIBCPP_HAS_MUSL_LIBC
+#    elif defined(__wasi__) || _LIBCPP_HAS_MUSL_LIBC || defined(__sun)
 #      include <__locale_dir/locale_base_api/musl.h>
 #    endif
 

--- a/libcxx/include/__math/abs.h
+++ b/libcxx/include/__math/abs.h
@@ -23,15 +23,9 @@ namespace __math {
 
 // fabs
 
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float fabs(float __x) _NOEXCEPT { return __builtin_fabsf(__x); }
-
 template <class = int>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double fabs(double __x) _NOEXCEPT {
   return __builtin_fabs(__x);
-}
-
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double fabs(long double __x) _NOEXCEPT {
-  return __builtin_fabsl(__x);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
@@ -40,13 +34,6 @@ template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 }
 
 // abs
-
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline float abs(float __x) _NOEXCEPT { return __builtin_fabsf(__x); }
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline double abs(double __x) _NOEXCEPT { return __builtin_fabs(__x); }
-
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline long double abs(long double __x) _NOEXCEPT {
-  return __builtin_fabsl(__x);
-}
 
 template <class = int>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline int abs(int __x) _NOEXCEPT {
@@ -62,6 +49,15 @@ template <class = int>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline long long abs(long long __x) _NOEXCEPT {
   return __builtin_llabs(__x);
 }
+
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float fabs(float __x) _NOEXCEPT { return __builtin_fabsf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double fabs(long double __x) _NOEXCEPT { return __builtin_fabsl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float abs(float __x) _NOEXCEPT { return __builtin_fabsf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double abs(double __x) _NOEXCEPT { return __builtin_fabs(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double abs(long double __x) _NOEXCEPT { return __builtin_fabsl(__x); }
+#endif
 
 } // namespace __math
 

--- a/libcxx/include/__math/exponential_functions.h
+++ b/libcxx/include/__math/exponential_functions.h
@@ -26,14 +26,10 @@ namespace __math {
 
 // exp
 
-inline _LIBCPP_HIDE_FROM_ABI float exp(float __x) _NOEXCEPT { return __builtin_expf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double exp(double __x) _NOEXCEPT {
   return __builtin_exp(__x);
 }
-
-inline _LIBCPP_HIDE_FROM_ABI long double exp(long double __x) _NOEXCEPT { return __builtin_expl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double exp(_A1 __x) _NOEXCEPT {
@@ -42,15 +38,9 @@ inline _LIBCPP_HIDE_FROM_ABI double exp(_A1 __x) _NOEXCEPT {
 
 // frexp
 
-inline _LIBCPP_HIDE_FROM_ABI float frexp(float __x, int* __e) _NOEXCEPT { return __builtin_frexpf(__x, __e); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double frexp(double __x, int* __e) _NOEXCEPT {
   return __builtin_frexp(__x, __e);
-}
-
-inline _LIBCPP_HIDE_FROM_ABI long double frexp(long double __x, int* __e) _NOEXCEPT {
-  return __builtin_frexpl(__x, __e);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
@@ -60,15 +50,9 @@ inline _LIBCPP_HIDE_FROM_ABI double frexp(_A1 __x, int* __e) _NOEXCEPT {
 
 // ldexp
 
-inline _LIBCPP_HIDE_FROM_ABI float ldexp(float __x, int __e) _NOEXCEPT { return __builtin_ldexpf(__x, __e); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double ldexp(double __x, int __e) _NOEXCEPT {
   return __builtin_ldexp(__x, __e);
-}
-
-inline _LIBCPP_HIDE_FROM_ABI long double ldexp(long double __x, int __e) _NOEXCEPT {
-  return __builtin_ldexpl(__x, __e);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
@@ -146,15 +130,9 @@ inline _LIBCPP_HIDE_FROM_ABI double scalbn(_A1 __x, int __y) _NOEXCEPT {
 
 // pow
 
-inline _LIBCPP_HIDE_FROM_ABI float pow(float __x, float __y) _NOEXCEPT { return __builtin_powf(__x, __y); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double pow(double __x, double __y) _NOEXCEPT {
   return __builtin_pow(__x, __y);
-}
-
-inline _LIBCPP_HIDE_FROM_ABI long double pow(long double __x, long double __y) _NOEXCEPT {
-  return __builtin_powl(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
@@ -163,6 +141,18 @@ inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> pow(_A1 __x, _A2 __y) _NOEXCE
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::pow((__result_type)__x, (__result_type)__y);
 }
+
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+inline _LIBCPP_HIDE_FROM_ABI float exp(float __x) _NOEXCEPT { return __builtin_expf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double exp(long double __x) _NOEXCEPT { return __builtin_expl(__x); }
+inline _LIBCPP_HIDE_FROM_ABI float frexp(float __x, int* __e) _NOEXCEPT { return __builtin_frexpf(__x, __e); }
+inline _LIBCPP_HIDE_FROM_ABI long double frexp(long double __x, int* __e) _NOEXCEPT { return __builtin_frexpl(__x, __e); }
+inline _LIBCPP_HIDE_FROM_ABI float ldexp(float __x, int __e) _NOEXCEPT { return __builtin_ldexpf(__x, __e); }
+inline _LIBCPP_HIDE_FROM_ABI long double ldexp(long double __x, int __e) _NOEXCEPT { return __builtin_ldexpl(__x, __e); }
+inline _LIBCPP_HIDE_FROM_ABI float pow(float __x, float __y) _NOEXCEPT { return __builtin_powf(__x, __y); }
+inline _LIBCPP_HIDE_FROM_ABI long double pow(long double __x, long double __y) _NOEXCEPT { return __builtin_powl(__x, __y); }
+#endif
 
 } // namespace __math
 

--- a/libcxx/include/__math/inverse_trigonometric_functions.h
+++ b/libcxx/include/__math/inverse_trigonometric_functions.h
@@ -26,14 +26,10 @@ namespace __math {
 
 // acos
 
-inline _LIBCPP_HIDE_FROM_ABI float acos(float __x) _NOEXCEPT { return __builtin_acosf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double acos(double __x) _NOEXCEPT {
   return __builtin_acos(__x);
 }
-
-inline _LIBCPP_HIDE_FROM_ABI long double acos(long double __x) _NOEXCEPT { return __builtin_acosl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double acos(_A1 __x) _NOEXCEPT {
@@ -42,14 +38,10 @@ inline _LIBCPP_HIDE_FROM_ABI double acos(_A1 __x) _NOEXCEPT {
 
 // asin
 
-inline _LIBCPP_HIDE_FROM_ABI float asin(float __x) _NOEXCEPT { return __builtin_asinf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double asin(double __x) _NOEXCEPT {
   return __builtin_asin(__x);
 }
-
-inline _LIBCPP_HIDE_FROM_ABI long double asin(long double __x) _NOEXCEPT { return __builtin_asinl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double asin(_A1 __x) _NOEXCEPT {
@@ -58,14 +50,10 @@ inline _LIBCPP_HIDE_FROM_ABI double asin(_A1 __x) _NOEXCEPT {
 
 // atan
 
-inline _LIBCPP_HIDE_FROM_ABI float atan(float __x) _NOEXCEPT { return __builtin_atanf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double atan(double __x) _NOEXCEPT {
   return __builtin_atan(__x);
 }
-
-inline _LIBCPP_HIDE_FROM_ABI long double atan(long double __x) _NOEXCEPT { return __builtin_atanl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double atan(_A1 __x) _NOEXCEPT {
@@ -74,15 +62,9 @@ inline _LIBCPP_HIDE_FROM_ABI double atan(_A1 __x) _NOEXCEPT {
 
 // atan2
 
-inline _LIBCPP_HIDE_FROM_ABI float atan2(float __y, float __x) _NOEXCEPT { return __builtin_atan2f(__y, __x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double atan2(double __x, double __y) _NOEXCEPT {
   return __builtin_atan2(__x, __y);
-}
-
-inline _LIBCPP_HIDE_FROM_ABI long double atan2(long double __y, long double __x) _NOEXCEPT {
-  return __builtin_atan2l(__y, __x);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
@@ -91,6 +73,18 @@ inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> atan2(_A1 __y, _A2 __x) _NOEX
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::atan2((__result_type)__y, (__result_type)__x);
 }
+
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+inline _LIBCPP_HIDE_FROM_ABI float acos(float __x) _NOEXCEPT { return __builtin_acosf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double acos(long double __x) _NOEXCEPT { return __builtin_acosl(__x); }
+inline _LIBCPP_HIDE_FROM_ABI float asin(float __x) _NOEXCEPT { return __builtin_asinf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double asin(long double __x) _NOEXCEPT { return __builtin_asinl(__x); }
+inline _LIBCPP_HIDE_FROM_ABI float atan(float __x) _NOEXCEPT { return __builtin_atanf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double atan(long double __x) _NOEXCEPT { return __builtin_atanl(__x); }
+inline _LIBCPP_HIDE_FROM_ABI float atan2(float __y, float __x) _NOEXCEPT { return __builtin_atan2f(__y, __x); }
+inline _LIBCPP_HIDE_FROM_ABI long double atan2(long double __y, long double __x) _NOEXCEPT { return __builtin_atan2l(__y, __x); }
+#endif
 
 } // namespace __math
 

--- a/libcxx/include/__math/logarithms.h
+++ b/libcxx/include/__math/logarithms.h
@@ -23,14 +23,10 @@ namespace __math {
 
 // log
 
-inline _LIBCPP_HIDE_FROM_ABI float log(float __x) _NOEXCEPT { return __builtin_logf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double log(double __x) _NOEXCEPT {
   return __builtin_log(__x);
 }
-
-inline _LIBCPP_HIDE_FROM_ABI long double log(long double __x) _NOEXCEPT { return __builtin_logl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double log(_A1 __x) _NOEXCEPT {
@@ -39,19 +35,23 @@ inline _LIBCPP_HIDE_FROM_ABI double log(_A1 __x) _NOEXCEPT {
 
 // log10
 
-inline _LIBCPP_HIDE_FROM_ABI float log10(float __x) _NOEXCEPT { return __builtin_log10f(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double log10(double __x) _NOEXCEPT {
   return __builtin_log10(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double log10(long double __x) _NOEXCEPT { return __builtin_log10l(__x); }
-
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double log10(_A1 __x) _NOEXCEPT {
   return __builtin_log10((double)__x);
 }
+
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+inline _LIBCPP_HIDE_FROM_ABI float log(float __x) _NOEXCEPT { return __builtin_logf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double log(long double __x) _NOEXCEPT { return __builtin_logl(__x); }
+inline _LIBCPP_HIDE_FROM_ABI float log10(float __x) _NOEXCEPT { return __builtin_log10f(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double log10(long double __x) _NOEXCEPT { return __builtin_log10l(__x); }
+#endif
 
 // ilogb
 

--- a/libcxx/include/__math/modulo.h
+++ b/libcxx/include/__math/modulo.h
@@ -25,15 +25,9 @@ namespace __math {
 
 // fmod
 
-inline _LIBCPP_HIDE_FROM_ABI float fmod(float __x, float __y) _NOEXCEPT { return __builtin_fmodf(__x, __y); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double fmod(double __x, double __y) _NOEXCEPT {
   return __builtin_fmod(__x, __y);
-}
-
-inline _LIBCPP_HIDE_FROM_ABI long double fmod(long double __x, long double __y) _NOEXCEPT {
-  return __builtin_fmodl(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
@@ -45,16 +39,18 @@ inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> fmod(_A1 __x, _A2 __y) _NOEXC
 
 // modf
 
-inline _LIBCPP_HIDE_FROM_ABI float modf(float __x, float* __y) _NOEXCEPT { return __builtin_modff(__x, __y); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double modf(double __x, double* __y) _NOEXCEPT {
   return __builtin_modf(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double modf(long double __x, long double* __y) _NOEXCEPT {
-  return __builtin_modfl(__x, __y);
-}
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+inline _LIBCPP_HIDE_FROM_ABI float fmod(float __x, float __y) _NOEXCEPT { return __builtin_fmodf(__x, __y); }
+inline _LIBCPP_HIDE_FROM_ABI long double fmod(long double __x, long double __y) _NOEXCEPT { return __builtin_fmodl(__x, __y); }
+inline _LIBCPP_HIDE_FROM_ABI float modf(float __x, float* __y) _NOEXCEPT { return __builtin_modff(__x, __y); }
+inline _LIBCPP_HIDE_FROM_ABI long double modf(long double __x, long double* __y) _NOEXCEPT { return __builtin_modfl(__x, __y); }
+#endif
 
 } // namespace __math
 

--- a/libcxx/include/__math/roots.h
+++ b/libcxx/include/__math/roots.h
@@ -23,19 +23,21 @@ namespace __math {
 
 // sqrt
 
-inline _LIBCPP_HIDE_FROM_ABI float sqrt(float __x) _NOEXCEPT { return __builtin_sqrtf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double sqrt(double __x) _NOEXCEPT {
   return __builtin_sqrt(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double sqrt(long double __x) _NOEXCEPT { return __builtin_sqrtl(__x); }
-
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double sqrt(_A1 __x) _NOEXCEPT {
   return __builtin_sqrt((double)__x);
 }
+
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+inline _LIBCPP_HIDE_FROM_ABI float sqrt(float __x) _NOEXCEPT { return __builtin_sqrtf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double sqrt(long double __x) _NOEXCEPT { return __builtin_sqrtl(__x); }
+#endif
 
 // cbrt
 

--- a/libcxx/include/__math/rounding_functions.h
+++ b/libcxx/include/__math/rounding_functions.h
@@ -26,15 +26,9 @@ namespace __math {
 
 // ceil
 
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float ceil(float __x) _NOEXCEPT { return __builtin_ceilf(__x); }
-
 template <class = int>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double ceil(double __x) _NOEXCEPT {
   return __builtin_ceil(__x);
-}
-
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double ceil(long double __x) _NOEXCEPT {
-  return __builtin_ceill(__x);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
@@ -44,21 +38,23 @@ template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 
 // floor
 
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float floor(float __x) _NOEXCEPT { return __builtin_floorf(__x); }
-
 template <class = int>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double floor(double __x) _NOEXCEPT {
   return __builtin_floor(__x);
-}
-
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double floor(long double __x) _NOEXCEPT {
-  return __builtin_floorl(__x);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double floor(_A1 __x) _NOEXCEPT {
   return __builtin_floor((double)__x);
 }
+
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float ceil(float __x) _NOEXCEPT { return __builtin_ceilf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double ceil(long double __x) _NOEXCEPT { return __builtin_ceill(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float floor(float __x) _NOEXCEPT { return __builtin_floorf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double floor(long double __x) _NOEXCEPT { return __builtin_floorl(__x); }
+#endif
 
 // llrint
 

--- a/libcxx/include/__math/trigonometric_functions.h
+++ b/libcxx/include/__math/trigonometric_functions.h
@@ -23,14 +23,10 @@ namespace __math {
 
 // cos
 
-inline _LIBCPP_HIDE_FROM_ABI float cos(float __x) _NOEXCEPT { return __builtin_cosf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double cos(double __x) _NOEXCEPT {
   return __builtin_cos(__x);
 }
-
-inline _LIBCPP_HIDE_FROM_ABI long double cos(long double __x) _NOEXCEPT { return __builtin_cosl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double cos(_A1 __x) _NOEXCEPT {
@@ -39,14 +35,10 @@ inline _LIBCPP_HIDE_FROM_ABI double cos(_A1 __x) _NOEXCEPT {
 
 // sin
 
-inline _LIBCPP_HIDE_FROM_ABI float sin(float __x) _NOEXCEPT { return __builtin_sinf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double sin(double __x) _NOEXCEPT {
   return __builtin_sin(__x);
 }
-
-inline _LIBCPP_HIDE_FROM_ABI long double sin(long double __x) _NOEXCEPT { return __builtin_sinl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double sin(_A1 __x) _NOEXCEPT {
@@ -55,19 +47,25 @@ inline _LIBCPP_HIDE_FROM_ABI double sin(_A1 __x) _NOEXCEPT {
 
 // tan
 
-inline _LIBCPP_HIDE_FROM_ABI float tan(float __x) _NOEXCEPT { return __builtin_tanf(__x); }
-
 template <class = int>
 _LIBCPP_HIDE_FROM_ABI double tan(double __x) _NOEXCEPT {
   return __builtin_tan(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double tan(long double __x) _NOEXCEPT { return __builtin_tanl(__x); }
-
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI double tan(_A1 __x) _NOEXCEPT {
   return __builtin_tan((double)__x);
 }
+
+// illumos <math.h> already provides float/long double overloads
+#ifndef __sun
+inline _LIBCPP_HIDE_FROM_ABI float cos(float __x) _NOEXCEPT { return __builtin_cosf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double cos(long double __x) _NOEXCEPT { return __builtin_cosl(__x); }
+inline _LIBCPP_HIDE_FROM_ABI float sin(float __x) _NOEXCEPT { return __builtin_sinf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double sin(long double __x) _NOEXCEPT { return __builtin_sinl(__x); }
+inline _LIBCPP_HIDE_FROM_ABI float tan(float __x) _NOEXCEPT { return __builtin_tanf(__x); }
+inline _LIBCPP_HIDE_FROM_ABI long double tan(long double __x) _NOEXCEPT { return __builtin_tanl(__x); }
+#endif
 
 } // namespace __math
 

--- a/libcxx/include/__ranges/zip_view.h
+++ b/libcxx/include/__ranges/zip_view.h
@@ -11,7 +11,6 @@
 #define _LIBCPP___RANGES_ZIP_VIEW_H
 
 #include <__config>
-
 #include <__algorithm/ranges_min.h>
 #include <__compare/three_way_comparable.h>
 #include <__concepts/convertible_to.h>

--- a/libcxx/include/__undef_macros
+++ b/libcxx/include/__undef_macros
@@ -26,3 +26,39 @@
 #ifdef erase
 #  undef erase
 #endif
+
+// illumos: sys/ccompile.h defines __sentinel as a macro for GCC's sentinel
+// attribute, which conflicts with libc++ using __sentinel as an identifier
+#ifdef __sun
+#  undef __sentinel
+#endif
+
+// illumos: wctype_iso.h defines _E1-_E24 as character class constants
+// which pollute libc++ template parameters like _E2
+// Note: _B and _C are kept because they're needed by __locale for ctype_base
+#ifdef __sun
+#  undef _E1
+#  undef _E2
+#  undef _E3
+#  undef _E4
+#  undef _E5
+#  undef _E6
+#  undef _E7
+#  undef _E8
+#  undef _E9
+#  undef _E10
+#  undef _E11
+#  undef _E12
+#  undef _E13
+#  undef _E14
+#  undef _E15
+#  undef _E16
+#  undef _E17
+#  undef _E18
+#  undef _E19
+#  undef _E20
+#  undef _E21
+#  undef _E22
+#  undef _E23
+#  undef _E24
+#endif

--- a/libcxx/include/stdlib.h
+++ b/libcxx/include/stdlib.h
@@ -121,8 +121,8 @@ using std::__math::abs;
 #        undef lldiv
 #      endif
 
-// MSVCRT already has the correct prototype in <stdlib.h> if __cplusplus is defined
-#      if !defined(_LIBCPP_MSVCRT)
+// MSVCRT and illumos already have the correct prototype in <stdlib.h> if __cplusplus is defined
+#      if !defined(_LIBCPP_MSVCRT) && !defined(__sun)
 inline _LIBCPP_HIDE_FROM_ABI ldiv_t div(long __x, long __y) _NOEXCEPT { return ::ldiv(__x, __y); }
 #        if !(defined(__FreeBSD__) && !defined(__LONG_LONG_SUPPORTED))
 inline _LIBCPP_HIDE_FROM_ABI lldiv_t div(long long __x, long long __y) _NOEXCEPT { return ::lldiv(__x, __y); }

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -749,10 +749,10 @@ public:
     return(N);
   }
 
-  iterator erase(const_iterator CS, const_iterator CE) {
+  iterator erase(const_iterator CCS, const_iterator CCE) {
     // Just cast away constness because this is a non-const member function.
-    iterator S = const_cast<iterator>(CS);
-    iterator E = const_cast<iterator>(CE);
+    iterator S = const_cast<iterator>(CCS);
+    iterator E = const_cast<iterator>(CCE);
 
     assert(this->isRangeInStorage(S, E) && "Range to erase is out of bounds.");
 

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -19,6 +19,12 @@
 #ifndef LLVM_SUPPORT_COMMANDLINE_H
 #define LLVM_SUPPORT_COMMANDLINE_H
 
+// illumos: sys/regset.h defines FS as a macro for segment register (value 1)
+// which conflicts with the FS parameter/member names in this file
+#ifdef __sun
+#  undef FS
+#endif
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"

--- a/llvm/include/llvm/Support/PGOOptions.h
+++ b/llvm/include/llvm/Support/PGOOptions.h
@@ -14,6 +14,12 @@
 #ifndef LLVM_SUPPORT_PGOOPTIONS_H
 #define LLVM_SUPPORT_PGOOPTIONS_H
 
+// illumos: sys/regset.h defines FS as a macro for segment register (value 1)
+// which conflicts with the FS parameter/member names in this file
+#ifdef __sun
+#  undef FS
+#endif
+
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -13,6 +13,12 @@
 #ifndef LLVM_TARGET_TARGETMACHINE_H
 #define LLVM_TARGET_TARGETMACHINE_H
 
+// illumos: sys/regset.h defines FS as a macro for segment register (value 1)
+// which conflicts with the FS parameter/member names in this file
+#ifdef __sun
+#  undef FS
+#endif
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/PassManager.h"

--- a/llvm/lib/Transforms/IPO/SampleProfileProbe.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileProbe.cpp
@@ -28,6 +28,7 @@
 #include "llvm/Support/CRC.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
+#include <cmath>
 #include "llvm/Transforms/Utils/Instrumentation.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include <unordered_set>
@@ -151,7 +152,7 @@ void PseudoProbeVerifier::verifyProbeFactors(
     auto [It, Inserted] = PrevProbeFactors.try_emplace(I.first);
     if (!Inserted) {
       float PrevProbeFactor = It->second;
-      if (std::abs(CurProbeFactor - PrevProbeFactor) >
+      if (std::fabs(CurProbeFactor - PrevProbeFactor) >
           DistributionFactorVariance) {
         if (!BannerPrinted) {
           dbgs() << "Function " << F->getName() << ":\n";


### PR DESCRIPTION
Add illumos support to libc++ and LLVM.

libc++ changes:
- Add __sun to pthread platforms and rune table providers.
- Add illumos ctype mask definitions with non-overlapping __regex_word.
- Use musl locale shim for missing *_l functions.
- Skip overloads already defined in illumos stdlib.
- Fix conflicting __sentinel, _E1-_E24 macros.

LLVM changes:
- Fix conflicting FS, CS/CE macros.
- Use std::fabs instead of std::abs for float in SampleProfileProbe.

Part of #23777.

cc @alexey-milovidov