### PR TITLE
[libunwind] Fix a freebsd regression introduced in #63.

### DIFF
--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -408,8 +408,9 @@ static bool checkAddrInSegment(const Elf_Phdr *phdr, size_t image_base,
 static bool checkForUnwindInfoSegment(const Elf_Phdr *phdr, size_t image_base,
                                       dl_iterate_cb_data *cbdata) {
 #if defined(_LIBUNWIND_SUPPORT_DWARF_INDEX)
-#if defined(PT_SUNW_UNWIND)
-  // illumos/Solaris use PT_SUNW_EH_FRAME and PT_SUNW_UNWIND instead of PT_GNU_EH_FRAME
+#if defined(PT_SUNW_EH_FRAME) && defined(PT_SUNW_UNWIND)
+  // illumos/Solaris use PT_SUNW_EH_FRAME and PT_SUNW_UNWIND instead of PT_GNU_EH_FRAME.
+  // FreeBSD defines PT_SUNW_UNWIND but not PT_SUNW_EH_FRAME, so check for both.
   if (phdr->p_type == PT_SUNW_EH_FRAME || phdr->p_type == PT_SUNW_UNWIND) {
 #else
   if (phdr->p_type == PT_GNU_EH_FRAME) {


### PR DESCRIPTION
In #63, we checked for illumos-specific EH headers and used them if defined. But freebsd also defines some of these headers (but not all) for compatibility. This patch caused clickhouse builds to break on freebsd. This patch fixes the regression by checking for both EH headers, so that we fall through to the default case on freebsd.