### PR TITLE
fix compatibility between hardening and asan

### DIFF
--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -60,6 +60,10 @@
 _LIBCPP_PUSH_MACROS
 #include <__undef_macros>
 
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+extern "C" std::size_t __asan_load_cxx_array_cookie(std::size_t*);
+#endif
+
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
@@ -351,7 +355,12 @@ struct __unique_ptr_array_bounds_stateless {
     // is in-bounds. The compiler catches invalid accesses anyway.
     if (__libcpp_is_constant_evaluated())
       return true;
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+    // With ASan enabled, reading cookie directly causes errors because the memory is poisoned.
+    size_t __cookie = __asan_load_cxx_array_cookie(reinterpret_cast<size_t*>(__ptr) - 1);
+#else
     size_t __cookie = std::__get_array_cookie(__ptr);
+#endif
     return __index < __cookie;
   }
 
@@ -379,7 +388,12 @@ struct __unique_ptr_array_bounds_stored {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool __in_bounds(_Tp* __ptr, size_t __index) const {
     if (__libcpp_is_constant_evaluated())
       return true;
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+    // With ASan enabled, reading cookie directly causes errors because the memory is poisoned.
+    size_t __cookie = __asan_load_cxx_array_cookie(reinterpret_cast<size_t*>(__ptr) - 1);
+#else
     size_t __cookie = std::__get_array_cookie(__ptr);
+#endif
     return __index < __cookie;
   }
 


### PR DESCRIPTION
In the [PR](https://github.com/ClickHouse/ClickHouse/pull/94757) where I enabled the hardening, there's an [ASan error](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94757&sha=5b10a589557d9116a765b61ad273d57a28bf3f24&name_0=PR) (consistent and unique to the PR - [cidb](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICdBZGRyZXNzU2FuaXRpemVyIChTVElEOiAzMDUwLTM1YTQpJwogICAgLS0gQU5EIGNoZWNrX25hbWUgPSAnU3RhdGVsZXNzIHRlc3RzIChhbWRfYXNhbiwgZGlzdHJpYnV0ZWQgcGxhbiwgcGFyYWxsZWwsIDIvMiknCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJykKICAgIEFORCAocHVsbF9yZXF1ZXN0X251bWJlciA9IDAgT1IgYmFzZV9yZWYgSU4gKCdtYXN0ZXInKSkKICAgIC0tIEFORCB0ZXN0X2NvbnRleHRfcmF3IExJS0UgJyVwYXR0ZXJuJScgIC0tIHVuY29tbWVudCBhbmQgZWRpdCB0byBmaWx0ZXIgYnkgZmFpbHVyZSBwYXR0ZXJuCkdST1VQIEJZIGRheQpPUkRFUiBCWSBkYXkgREVTQwo=)).

It occurs in unique_ptr [code](https://github.com/ClickHouse/llvm-project/blob/clickhouse1/libcxx/include/__memory/unique_ptr.h#L581):
```
#0 0x55e850dee87e in std::__1::unique_ptr<DB::(anonymous namespace)::AggregateFunctionThrowData [], std::__1::default_delete<DB::(anonymous namespace)::AggregateFunctionThrowData []>>::operator[][abi:fe210105](unsigned long) const ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:581:5
```

because `__in_bounds` [reads](https://github.com/ClickHouse/llvm-project/blob/clickhouse1/libcxx/include/__memory/unique_ptr.h#L382) array cookie directly from memory which is marked as poisoned by the sanitizer.

That should be read via `__asan_load_cxx_array_cookie` ([code](https://github.com/ClickHouse/llvm-project/blob/clickhouse1/compiler-rt/lib/asan/asan_poisoning.cpp#L329)) instead as it checks if the memory is marked as `kAsanArrayCookieMagic` and if so, just returns the cookie.