### PR TITLE
llvm/cmake/config.guess: add support for e2k (Elbrus-2000)

### DIFF
--- a/llvm/cmake/config.guess
+++ b/llvm/cmake/config.guess
@@ -908,6 +908,9 @@ EOF
     crisv32:Linux:*:*)
 	echo crisv32-axis-linux-gnu
 	exit ;;
+    e2k:Linux:*:*)
+	echo ${UNAME_MACHINE}-unknown-linux-gnu
+	exit ;;
     frv:Linux:*:*)
 	echo frv-unknown-linux-gnu
 	exit ;;


### PR DESCRIPTION
backport patch from llvm/llvm-project:
- https://github.com/llvm/llvm-project/commit/a523ee6e7acb43f04a59fc6077c119cd9a5428c1