### PR TITLE
[libc++] Drop routing to nonexistent locale shims.

### DIFF
--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -132,8 +132,6 @@
 #      include <__locale_dir/locale_base_api/ibm.h>
 #    elif defined(__OpenBSD__)
 #      include <__locale_dir/locale_base_api/openbsd.h>
-#    elif defined(__wasi__) || _LIBCPP_HAS_MUSL_LIBC || defined(__sun)
-#      include <__locale_dir/locale_base_api/musl.h>
 #    endif
 
 #    include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>


### PR DESCRIPTION
LLVM previously included shims for strtoll_l and strtoull_l for distributions that don't expose those functions. However, with the upgrade to 22.x, LLVM learned to parse integers itself, without relying on those functions, and dropped the shim. Routing to __locale_dir/locale_base_api/musl.h now fails, since the shim was removed on upgrade.

This patch drops the now-unnecessary routing to a file that doesn't exist. Note that we don't need to backport this change to upstream LLVM, since the shim and routing to it are already removed there.

cc @alexey-milovidov 