### PR TITLE
Use __cxa_thread_atexit_impl shim on illumos.

### DIFF
--- a/libcxxabi/src/cxa_thread_atexit.cpp
+++ b/libcxxabi/src/cxa_thread_atexit.cpp
@@ -104,7 +104,7 @@ namespace {
 } // namespace
 
 
-#if defined(__linux__) || defined(__Fuchsia__)
+#if defined(__linux__) || defined(__Fuchsia__) || defined(__sun)
 extern "C" {
 
     _LIBCXXABI_FUNC_VIS int __cxa_thread_atexit_impl(Dtor dtor, void* obj, void* dso_symbol) throw() {
@@ -137,5 +137,5 @@ extern "C" {
       return __cxa_thread_atexit_impl(dtor, obj, dso_symbol);
   }
 } // extern "C"
-#endif // defined(__linux__) || defined(__Fuchsia__)
+#endif // defined(__linux__) || defined(__Fuchsia__) || defined(__sun)
 } // namespace __cxxabiv1


### PR DESCRIPTION
libcxxabi offers a shim around __cxa_thread_atexit_impl for platforms that don't provide it. Since illumos doesn't provide this feature, include __sun in the guard so that the libcxxabi shim is available.