### PR TITLE
[msan] Keep the stack when an async signal arrives during a report

### DIFF
--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -24,6 +24,10 @@
 #include "sanitizer_common/sanitizer_flags.h"
 #include "sanitizer_common/sanitizer_interface_internal.h"
 #include "sanitizer_common/sanitizer_libc.h"
+#include "sanitizer_common/sanitizer_platform.h"
+#if SANITIZER_LINUX
+#  include "sanitizer_common/sanitizer_linux.h"
+#endif
 #include "sanitizer_common/sanitizer_procmaps.h"
 #include "sanitizer_common/sanitizer_stackdepot.h"
 #include "sanitizer_common/sanitizer_stacktrace.h"
@@ -243,6 +247,16 @@ void PrintWarningWithOrigin(uptr pc, uptr bp, u32 origin) {
   }
 
   ++msan_report_count;
+
+#if SANITIZER_LINUX
+  // Reporting is slow (out-of-process symbolization), and ScopedErrorReportLock
+  // aborts the whole process without printing anything if the same thread
+  // re-enters while a report is in flight. Defer asynchronous signals until the
+  // report is done so a handler that touches uninitialized memory cannot wipe
+  // it. Synchronous signals (SIGSEGV, SIGABRT, ...) stay unblocked, so a real
+  // crash while reporting still aborts as before.
+  ScopedBlockSignals block(nullptr);
+#endif
 
   GET_FATAL_STACK_TRACE_PC_BP(pc, bp);
 

--- a/compiler-rt/test/msan/Linux/nested_report_async_signal.cpp
+++ b/compiler-rt/test/msan/Linux/nested_report_async_signal.cpp
@@ -1,0 +1,83 @@
+// An asynchronous signal delivered while a report is being printed must not
+// abort the report. ScopedErrorReportLock treats same-thread reentrancy as a
+// nested bug and calls internal__exit() without printing anything, so the
+// original report used to be lost with zero frames.
+//
+// The signal is raised from __sanitizer_on_print, which the runtime calls for
+// every line it prints. That happens while the report lock is held and after
+// the first line of the report has already been written, so the signal always
+// lands inside the report window instead of at a timer-dependent moment.
+
+// RUN: %clangxx_msan -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -O1 %s -o %t && \
+// RUN:     not %run %t >%t.out 2>&1
+// RUN: FileCheck %s -implicit-check-not="nested bug in the same thread" < %t.out
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static volatile int sink;
+static volatile sig_atomic_t armed;
+static volatile sig_atomic_t raised;
+
+// Reads uninitialized memory, so the handler itself wants to report.
+static void handler(int, siginfo_t *, void *) {
+  char *p = (char *)malloc(64);
+  if (p[13])
+    sink = 1;
+  free(p);
+}
+
+__attribute__((disable_sanitizer_instrumentation)) static bool
+contains(const char *str, const char *sub) {
+  for (; *str; ++str) {
+    const char *a = str;
+    const char *b = sub;
+    while (*b && *a == *b) {
+      ++a;
+      ++b;
+    }
+    if (!*b)
+      return true;
+  }
+  return false;
+}
+
+// Overrides the weak definition in the runtime, so it runs inside the report.
+// Fire once, on the report's own first line.
+__attribute__((disable_sanitizer_instrumentation)) extern "C" void
+__sanitizer_on_print(const char *str) {
+  if (armed && !raised && contains(str, "use-of-uninitialized-value")) {
+    raised = 1;
+    raise(SIGUSR1);
+  }
+}
+
+__attribute__((noinline)) void report_here() {
+  char *q = (char *)malloc(64);
+  if (q[7])
+    sink = 2;
+  free(q);
+}
+
+int main() {
+  struct sigaction sa = {};
+  sa.sa_sigaction = handler;
+  sa.sa_flags = SA_SIGINFO | SA_RESTART;
+  if (sigaction(SIGUSR1, &sa, nullptr))
+    return 2;
+
+  armed = 1;
+  report_here();
+  printf("unreachable\n");
+  return 0;
+}
+
+// The surviving report must be report_here's: nothing raises the signal before
+// the runtime starts printing that report.
+// CHECK: WARNING: MemorySanitizer: use-of-uninitialized-value
+// CHECK: {{^ +#0 .*report_here}}
+// CHECK: {{^ +#1 }}
+// CHECK: Uninitialized value was created by a heap allocation
+// CHECK: SUMMARY: MemorySanitizer: use-of-uninitialized-value{{.*}}report_here
+// CHECK-NOT: unreachable


### PR DESCRIPTION

MSan intermittently produces a report with no stack at all:

```
==117==WARNING: MemorySanitizer: use-of-uninitialized-value
MemorySanitizer: nested bug in the same thread, aborting.
LLVM ERROR: IO failure on output stream: Broken pipe
```

`ScopedErrorReportLock::Lock` records the reporting thread and clears it only in `Unlock`. Printing a report is slow, because `stack->Print` and `ReportErrorSummary` round-trip to the out-of-process `llvm-symbolizer`. If an asynchronous signal is delivered to the reporting thread inside that window and its handler touches uninitialized memory, the second report re-enters the lock, takes the same-thread branch and calls `internal__exit` without printing anything. The first report is lost, and the pipe to the abandoned symbolizer child produces the trailing `LLVM ERROR` line. Upstream `sanitizer_symbolizer_report.cpp` documents this case ("This is either asynch signal or nested error during error reporting") but does not prevent it.

This is easy to hit in practice: ClickHouse arms a per-thread profiling timer on every query thread, so every MSan report races with a signal. Its CI has collected 23 of these empty reports in the last 30 days on both x86_64 and AArch64, across six different MSan job types, and none can be diagnosed.

Block asynchronous signals for the duration of the report in `PrintWarningWithOrigin`, the single funnel every UMR report goes through, placed after the existing `msan_expect_umr` early-return so `__msan_expect_umr` tests are unaffected. On Linux `BlockSignals` keeps the synchronous signals (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGTRAP`, `SIGABRT`, `SIGFPE`, `SIGPIPE`), `SIGSYS` and `SIGSETXID` unblocked, so a genuine crash while reporting still aborts as before, and it never unblocks a signal the caller had deliberately blocked. Those exemptions are themselves inside `#if SANITIZER_LINUX`, so the change is gated on `SANITIZER_LINUX`: elsewhere `BlockSignals` would mask `SIGSEGV` too.

The mask covers only the report body. `ScopedErrorReportLock` releases inside `ReportUMR`, so a signal arriving during the caller's `Die()` can no longer reach the same-thread branch, and `__msan_warning_noreturn`'s unconditional `Die()` still runs outside the mask.

`ScopedBlockSignals` is already MSan's tool for this class of protection (`MsanTSDDtor`, the `pthread_create` interceptor) and has its own unit test, so this adds no new state.

Measured with the new test, 50 runs each, against a runtime built from this branch:

| runtime | `nested bug` aborts | stack frames |
|---|---|---|
| without the change | 50/50 | 0 |
| with the change | 0/50 | 1600 (full stack + origin chain + `SUMMARY`) |

Removing only the added line and rebuilding returns it to 50/50 aborts with 0 frames. A synchronous `SIGSEGV` or `SIGABRT` raised inside the report window still produces a deadly-signal report and still aborts. The synchronous interceptor report path (`CHECK_UNPOISONED_0` via `memcmp`) is unchanged and unaffected.

Not covered: a nested report from a *different* thread (correctly serialized by `ScopedErrorReportLock`), the same defect in ASan/TSan/UBSan report funnels (not observed), and non-Linux platforms (unchanged, still affected).

I intend to offer this to `llvm/llvm-project` as well; there is no upstream issue or PR for it today.

The paired ClickHouse submodule bump is ClickHouse/ClickHouse#112008.

